### PR TITLE
fix timeout application on socket on windows

### DIFF
--- a/librtmp/rtmp_sys.h
+++ b/librtmp/rtmp_sys.h
@@ -42,7 +42,7 @@
 #define EWOULDBLOCK	WSAETIMEDOUT	/* we don't use nonblocking, but we do use timeouts */
 #define sleep(n)	Sleep(n*1000)
 #define msleep(n)	Sleep(n)
-#define SET_SOCKOPT_TIMEO(tv,s)	int tv = s*1000
+#define SET_SOCKOPT_TIMEO(tv,s)	struct timeval tv = {s,0}
 #else /* !_WIN32 */
 #include <sys/types.h>
 #include <sys/socket.h>


### PR DESCRIPTION
changed the wrong definition of macro that sets a socket timeout on windows, which would end up in socket timeout not being applied (or with a very wrong value probably)