### PR TITLE
Fix socket's stream timeout

### DIFF
--- a/librtmp/rtmp.c
+++ b/librtmp/rtmp.c
@@ -943,7 +943,7 @@ RTMP_Connect0(RTMP *r, struct sockaddr * service)
           fd_set fdset;
           FD_ZERO(&fdset);
           FD_SET(r->m_sb.sb_socket, &fdset);
-          SET_SOCKOPT_TIMEO(selectTv, r->Link.timeout);
+          SET_SOCKCONNECT_TIMEO(selectTv, r->Link.timeout);
           int selectReturn = select(r->m_sb.sb_socket + 1, NULL, &fdset, NULL, &selectTv);
           if (selectReturn == -1) {
               RTMP_Log(RTMP_LOGERROR, "%s, failed to connect socket during select. %d (%s)",

--- a/librtmp/rtmp_sys.h
+++ b/librtmp/rtmp_sys.h
@@ -42,7 +42,8 @@
 #define EWOULDBLOCK	WSAETIMEDOUT	/* we don't use nonblocking, but we do use timeouts */
 #define sleep(n)	Sleep(n*1000)
 #define msleep(n)	Sleep(n)
-#define SET_SOCKOPT_TIMEO(tv,s)	struct timeval tv = {s,0}
+#define SET_SOCKOPT_TIMEO(tv,s)	int tv = s*1000
+#define SET_SOCKCONNECT_TIMEO(tv,s)	struct timeval tv = {s,0}
 #else /* !_WIN32 */
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -58,6 +59,7 @@
 #define closesocket(s)	close(s)
 #define msleep(n)	usleep(n*1000)
 #define SET_SOCKOPT_TIMEO(tv,s)	struct timeval tv = {s,0}
+#define SET_SOCKCONNECT_TIMEO(tv,s)	SET_SOCKOPT_TIMEO(tv, s)
 #endif
 
 #include "rtmp.h"


### PR DESCRIPTION
We need two macros for convertinf timeout for socket's select and for set socket options

On Unix, both operations require timeout as timeval struct, on windows socket's select requires timeout as a timeval struct, while set socket options requires timeout as an int, representing milliseconds